### PR TITLE
Add property to control whether exchange declarations are active

### DIFF
--- a/src/main/java/com/axis/eiffel/gerrit/herald/RabbitMQ/Sender.java
+++ b/src/main/java/com/axis/eiffel/gerrit/herald/RabbitMQ/Sender.java
@@ -52,11 +52,16 @@ public class Sender extends Rabbitmq {
      *
      * @param exchangeName Name of the exchange
      * @param type Exchange type
+     * @param activeDeclare Whether the exchange should be actively declared
      * @throws IOException
      */
-    public void setExchange(String exchangeName, String type) throws IOException {
+    public void setExchange(String exchangeName, String type, boolean activeDeclare) throws IOException {
         this.exchangeName = exchangeName;
-        channel.exchangeDeclare(this.exchangeName, type, true);
+        if (activeDeclare) {
+            channel.exchangeDeclare(this.exchangeName, type, true);
+        } else {
+            channel.exchangeDeclarePassive(this.exchangeName);
+        }
     }
 
     /**

--- a/src/main/java/com/axis/eiffel/gerrit/herald/Service.java
+++ b/src/main/java/com/axis/eiffel/gerrit/herald/Service.java
@@ -43,6 +43,7 @@ import static com.axis.eiffel.gerrit.herald.ServiceProperties.R_QUEUE_NAME;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.R_ROUTING_KEY;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.R_USERNAME;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.R_VIRTUALHOST;
+import static com.axis.eiffel.gerrit.herald.ServiceProperties.S_EXCHANGE_ACTIVE;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.S_EXCHANGE_NAME;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.S_EXCHANGE_TYPE;
 import static com.axis.eiffel.gerrit.herald.ServiceProperties.S_HOST;
@@ -133,7 +134,8 @@ public class Service {
                     S_VIRTUALHOST.getValue());
             receiver = new Receiver(R_USERNAME.getValue(), R_PASSWORD.getValue(), R_HOST.getValue(),
                     R_VIRTUALHOST.getValue());
-            sender.setExchange(S_EXCHANGE_NAME.getValue(), S_EXCHANGE_TYPE.getValue());
+            sender.setExchange(S_EXCHANGE_NAME.getValue(), S_EXCHANGE_TYPE.getValue(),
+                    Boolean.parseBoolean(S_EXCHANGE_ACTIVE.getValue()));
             receiver.setQueue(R_QUEUE_NAME.getValue(), R_EXCHANGE_NAME.getValue(), R_ROUTING_KEY.getValue());
         } catch (IOException | TimeoutException | NoSuchAlgorithmException | KeyManagementException e) {
             log.error("Could not start connection to RabbitMQ: " + e.getMessage() + "\nCause: " + e.getCause());

--- a/src/main/java/com/axis/eiffel/gerrit/herald/ServiceProperties.java
+++ b/src/main/java/com/axis/eiffel/gerrit/herald/ServiceProperties.java
@@ -39,6 +39,7 @@ public enum ServiceProperties {
     R_VIRTUALHOST,
     S_EXCHANGE_NAME,
     S_EXCHANGE_TYPE,
+    S_EXCHANGE_ACTIVE,
     S_USERNAME,
     S_PASSWORD,
     S_HOST,

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -11,6 +11,7 @@ R_VIRTUALHOST=/
 # Sender
 S_EXCHANGE_NAME=gerrit.to.eiffel
 S_EXCHANGE_TYPE=topic
+S_EXCHANGE_ACTIVE=true
 S_USERNAME=guest
 S_PASSWORD=guest
 S_HOST=localhost


### PR DESCRIPTION
### Applicable Issues
Fixes #7 

### Description of the Change
Previously all exchange declarations were made with Channel.exchangeDeclare(), i.e. an active declaration that requires that the user has the configure permission for the exchange in question. Because that permission allows the user to delete the exchange it's rarely granted except to broker administrators

The new S_EXCHANGE_ACTIVE boolean property controls whether exchange declarations are active or passive.

### Alternate Designs
We could've made all declarations passive and required users to prepare the RabbitMQ instance before Gerrit Herald started. I would've been fine with that but I'm sure there are cases where that wouldn't have been convenient.

### Benefits
Greater compatibility and fewer deployment restrictions.

### Possible Drawbacks
None except a slightly more convoluted configuration interface.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
