### PR TITLE
Rewrite dockerfile to use multi-stage build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Download and cd repo `git clone https://github.com/eiffel-community/eiffel-gerri
 
 Set config in `src/main/resources/config.properties`
 
+Additionally, if you run Gerrit Herald via Docker, the following
+environment variables can be set to affect the program's runtime
+behavior:
+
+| Variable      | Meaning
+| ------------- | --------
+| HERALD_OPTS   | Options to pass to Eiffel Gerrit Herald itself. |
+| JAVA_OPTS     | Options to pass to the JVM (e.g. "-Xmx1g -Dproperty=value"). |
+
 ### Build
 `docker-compose build`
 


### PR DESCRIPTION
### Applicable Issues
Fixes #4 

### Description of the Change
By using a multi-stage build we reduce the image size from 957 MB to 500 MB. We also reduce the size of the layers that need to be pushed after making a minimal change to the source code to just the size of the jar file (about 30 MB). Previously hundreds of MB of layers had to be pushed every time (at least partly because we downloaded Gradle every time).

We also add two environment variables that can be set to pass extra options to the JVM and to Gerrit Herald.

Finally, by using exec in the image entrypoint we make sure the JVM ends up as pid 1 so it gets the SIGTERM signal when the container is stopped.

### Alternate Designs
We could've use a Docker image that's more geared towards the purpose of running a Java application, one of fabric8's many images, but I chose to make the change minimal.

I also considered introducing an entrypoint script instead of using a shell-mode ENTRYPOINT. That way we would've supported passing additional Gerrit Herald options via the command-line (equivalent to a shell-mode CMD directive). Chose not to do this because of the increased complexity, and up until now we haven't supported passing Gerrit Herald options anyway.

### Benefits
Smaller image size, better handling of OS signals, better ability to configure the JVM.

### Possible Drawbacks
None in particular.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
