### PR TITLE
Make path to property file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Visit [Eiffel Community](https://eiffel-community.github.io) to get started and 
 ### Prepare
 Download and cd repo `git clone https://github.com/eiffel-community/eiffel-gerrit-herald.git && cd eiffel-gerrit-herald`
 
-Set config in `src/main/resources/config.properties`
+Set config in `src/main/resources/config.properties`. If you don't
+want to store your configuration in the jar file that's produced by
+the build, the `herald.properties` system property can be set to
+contain the path to the property file to load instead of the one
+built into the executable.
 
 ### Build
 `docker-compose build`

--- a/src/main/java/com/axis/eiffel/gerrit/herald/ServiceProperties.java
+++ b/src/main/java/com/axis/eiffel/gerrit/herald/ServiceProperties.java
@@ -18,7 +18,9 @@ package com.axis.eiffel.gerrit.herald;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -51,7 +53,14 @@ public enum ServiceProperties {
     ServiceProperties() {
         properties = new Properties();
         try {
-            properties.load(getClass().getClassLoader().getResourceAsStream("config.properties"));
+            InputStream propertyStream;
+            String customPropertyFileLocation = System.getProperty("herald.properties");
+            if (customPropertyFileLocation != null) {
+                propertyStream = new FileInputStream(customPropertyFileLocation);
+            } else {
+                propertyStream = getClass().getClassLoader().getResourceAsStream("config.properties");
+            }
+            properties.load(propertyStream);
             value = Objects.requireNonNull(properties.get(this.toString()));
         } catch (IOException e) {
             log.error("Unable to load config file. " + e.getMessage() + "\nCause: " + e.getCause());


### PR DESCRIPTION
### Applicable Issues
Fixes #3

### Description of the Change
Welding the configuration into the Docker image doesn't fit everyone, and up until now it hasn't been possible to change the configuration in config.properties in any other way. Introduce a herald.properties system property that can be set to the file system path of the property file to load. If the property is unset it'll fall back to the config.properties file in the jar file, i.e. this change is backwards compatible.

### Alternate Designs
While I'm not a fan of Java property files it's standard fare for Java applications. Controlling the path to them via system properties is also common, perhaps more common than using a command-line option for setting the path.

### Benefits
No need to wire (sensitive) configuration in the Docker image. More deployment options.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
